### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
       go-version-file: go.mod
       aqua_policy_allow: true
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,9 @@ jobs:
 
   test:
     uses: ./.github/workflows/wc-test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,20 +1,29 @@
 ---
 name: wc-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
 
   integration-test:
     timeout-minutes: 20
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -22,6 +31,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1


### PR DESCRIPTION
Introduce takumi guard (the Go variant) into the CI workflows to guard against malicious Go module activity.

## Changes

- `.github/workflows/release.yaml`: Add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `go-release-workflow` call (the ref was already pinned to `@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0`).
- `.github/workflows/wc-test.yaml`:
  - Declare the `TAKUMI_GUARD_BOT_ID` secret as `required: true` under `on.workflow_call.secrets`.
  - Bump the `go-test-full-workflow` call from `# v5.0.2` (`e442a17816baa8a940edc1544cc6e739d870e165`) to `# v6.0.0` (`98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb`), add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID`, and add `id-token: write` to the job's `permissions`.
  - In the `integration-test` job, add `contents: read` and `id-token: write` permissions (was `{}`) and insert the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` setup step immediately after `actions/setup-go` and before `aqua-installer` / `go install`.
- `.github/workflows/test.yaml`: In the `test` job that calls `./.github/workflows/wc-test.yaml`, add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` and add `id-token: write` to the job's `permissions` so the secret and OIDC token reach the reusable workflow chain.

## Note

This bumps `go-test-full-workflow` across a MAJOR version (v5.0.2 -> v6.0.0). Please review CI for any breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)