### PR TITLE
docs: link Sourcey-generated llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/suzuki-shunsuke/tfmv)
 [Install](docs/install.md)
+[AI-readable Go API index (llms.txt)](https://mitre88.github.io/tfmv-sourcey-docs/llms.txt)
 
 tfmv is a CLI to rename Terraform resources, data sources, and modules and generate moved blocks.
 


### PR DESCRIPTION
Closes #674

## Why

Adds a discoverable AI-readable Go API index generated by Sourcey from the pinned tfmv source commit `4ca60e60ae57983f57474f77ac294952279ef783`.

## Validation

- `go test ./...`
- Sourcey `3.6.5` generated 8 API pages
- Two independent generations produced SHA-256 `048f8143d93a266dabb4dfa8bafdd51513903ea8b2c499e5061e6a16e5bd40a3`
- All 8 generated index entries resolve locally
- Five public API links were independently audited with HTTP 200
- Public index: https://mitre88.github.io/tfmv-sourcey-docs/llms.txt
- Reproducible source and receipt: https://github.com/mitre88/tfmv-sourcey-docs

No runtime dependencies or behavior changes are introduced.

AI assistance was used to prepare this documentation contribution. I manually reviewed the change, regenerated the artifacts, audited the links, and ran the Go test suite.